### PR TITLE
fix(cask):tap caskroom/versions to be able to install docker-edge

### DIFF
--- a/mac.yml
+++ b/mac.yml
@@ -4,6 +4,11 @@
   hosts: local
 
   tasks:
+
+  - name: Tap caskroom/versions for edge versions
+    homebrew_tap:
+      name: caskroom/versions
+
   - name: Install dev utilities
     homebrew: name={{ item }}
     with_items:


### PR DESCRIPTION
Cask was not able to find docker-edge, this will fix that issue.