### PR TITLE
fix(deprications):fix homebrew and sudo modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@ Genesis will setup your Macbook from scratch
 ```
 curl -fsSL https://raw.githubusercontent.com/bangthetable/genesis/master/start | ruby
 ```
+The above command will prompt for installing xcode-select, after that installs, enter the password and continue with the script.
+This script will clone the genesis repo into `/tmp/genesis` and then run it for you.
+
+For some reson if it fails and you need to run the script again, you can run it with the follwoing command:
+
+```
+cd /tmp/genesis
+ansible-playbook -K mac.yml
+```
 
 ## What it installs
 

--- a/mac.yml
+++ b/mac.yml
@@ -2,6 +2,7 @@
 
 - name: Macbook Setup
   hosts: local
+  become_method: sudo
 
   tasks:
 
@@ -10,26 +11,12 @@
       name: homebrew/cask-versions
 
   - name: Install dev utilities
-    homebrew: name={{ item }}
-    with_items:
-      - vim
-      - git
-      - fzf
-      - the_silver_searcher
-      - zsh
-      - z
-      - dnsmasq
+    homebrew:
+      name: ['vim', 'git', 'fzf', 'the_silver_searcher', 'zsh', 'dnsmasq']
 
   - name: Install common software
-    homebrew_cask: name={{ item }}
-    with_items:
-      - google-chrome
-      - firefox
-      - slack
-      - iterm2
-      - sublime-text
-      - alfred
-      - docker-edge
+    homebrew_cask:
+      name: ['google-chrome', 'firefox', 'slack', 'iterm2', 'sublime-text', 'alfred', '1password', 'docker-edge']
 
   - name: Install oh-my-zsh
     shell: curl -L http://install.ohmyz.sh | sh creates=~/.oh-my-zsh
@@ -47,7 +34,6 @@
     copy: src=file/.gitmessage dest={{ ansible_user_dir }}/.gitmessage
 
   - name: Setup an alias for the loopback adapter
-    sudo: yes
     copy:
       src: loopback.alias.plist
       dest: /Library/LaunchDaemons/loopback.alias.plist
@@ -59,7 +45,6 @@
       dest: /usr/local/etc/dnsmasq.conf
 
   - name: Copy dnsmasq startup plist file
-    sudo: yes
     copy:
       src: homebrew.mxcl.dnsmasq.plist
       dest: /Library/LaunchDaemons/homebrew.mxcl.dnsmasq.plist


### PR DESCRIPTION
1. `sudo: yes` is deprecated in favour of become
2. `homebrew with {{ item }}` is deprecated, instead ansible
allows you to put an array of software names to be installed.
ALso update the Readme with this.