### PR TITLE
fix(ansible):change the user shell to zsh manually

### DIFF
--- a/mac.yml
+++ b/mac.yml
@@ -18,6 +18,10 @@
     homebrew_cask:
       name: ['google-chrome', 'firefox', 'slack', 'iterm2', 'sublime-text', 'alfred', '1password', 'docker-edge']
 
+  - name: Change user shell to zsh
+    user: name={{ ansible_user_id }} shell=/bin/zsh
+    become: true
+
   - name: Install oh-my-zsh
     shell: curl -L http://install.ohmyz.sh | sh creates=~/.oh-my-zsh
     args:


### PR DESCRIPTION
Recently, the installation of zsh does not change the shell to zsh, it
still remains /bin/bash, so manually changing it zsh