### PR TITLE
feat(ansible):add a task to install the docker-sync gem

### DIFF
--- a/mac.yml
+++ b/mac.yml
@@ -30,6 +30,10 @@
   - name: Initialize z on shell init
     lineinfile: dest=~/.zshrc line=". `brew --prefix`/etc/profile.d/z.sh"
 
+  - name: Install docker-sync gem
+    gem:
+      name: docker-sync
+
   - name: Setup sample gitconfig
     copy: src=file/.gitconfig dest={{ ansible_user_dir }}/.gitconfig
 


### PR DESCRIPTION
This gem is used in local for local host to container sync as native
sync in docker has very bad performance.